### PR TITLE
Fix Freesound Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_STORE

--- a/freesound/README.md
+++ b/freesound/README.md
@@ -15,14 +15,14 @@ Freesound only hands out client keys, not access keys. So, whereas using the
 access keys someone could post tweets from your Twitter account, the same
 isn't true for Freesound.
 
-5. Anyway, note down the client ID and API key.
+5. Anyway, note down the Client ID and API key.
 
 6. In this freesound folder, you should see a file named .env-template. This is
 an environment file, it contains key-value pairs that other applications, like
 Node, can load before running.
 
 7. Duplicate the .env-template file to a new file named ".env". It must be named
-".env", not "my.env" or anything like that. Fill in this file using the keys
+".env", not "my.env" or anything like that. Fill in this file using the API credentials
 you got from Freesound.
 
 8. You should be all set. Open the Max patcher freesound.maxpat and see!

--- a/freesound/fs-index.js
+++ b/freesound/fs-index.js
@@ -3,14 +3,7 @@
 //
 // Check the README for information on how to get a Freesound API key,
 // which you'll need in order to get any of this to work.
-//
-// This script uses a fork of the freesound NPM package, availiable here:
-// https://github.com/Girlfriends/freesound.js
-//
 // ---------------------------------------------------------------------
-
-// Begin loading modules
-
 
 const maxAPI = require("max-api");
 
@@ -26,106 +19,86 @@ try {
 }
 
 // Make sure that the API keys are loaded. Dotenv will put them in process.env if they are.
+if (!process.env.FREESOUND_CLIENT_ID) {
+	maxAPI.post("No value for key FREESOUND_CLIENT_ID in .env file. Please make sure to create a file called .env with a Freesound API Client ID.", maxAPI.POST_LEVELS.ERROR);
+	process.exit(1);
+}
+
 if (!process.env.FREESOUND_CLIENT_KEY) {
-	maxAPI.post("No value for key FREESOUND_CLIENT_KEY in .env file. Please make sure to create a file called .env with a Freesound API Client key.", maxAPI.POST_LEVELS.ERROR);
+	maxAPI.post("No value for key FREESOUND_CLIENT_KEY in .env file. Please make sure to create a file called .env with a Freesound API Key.", maxAPI.POST_LEVELS.ERROR);
 	process.exit(1);
 }
 
-if (!process.env.FREESOUND_CLIENT_SECRET) {
-	maxAPI.post("No value for key FREESOUND_CLIENT_SECRET in .env file. Please make sure to create a file called .env with a Freesound API Client Secret.", maxAPI.POST_LEVELS.ERROR);
-	process.exit(1);
-}
-
-// Create a freesound client object, using the keys from the process.
-const freesound = require("freesound");
-freesound.setClientSecrets(process.env.FREESOUND_CLIENT_KEY, process.env.FREESOUND_CLIENT_SECRET);
+// Create an Axios HTTP Request instance using the API keys from the process.
+const axios = require("axios").default;
+const freesoundRequest = axios.create({
+	baseURL: "https://freesound.org/apiv2",
+	headers: {
+		Authorization: `Token ${process.env.FREESOUND_CLIENT_KEY}`
+	}
+});
 
 const fs = require("fs");
-const http = require("http");
 const tmp = require("tmp");
 const path = require("path");
+const { promisify } = require("util");
+
+const tmpName = promisify(tmp.tmpName);
 
 // Freesound won't let us download directly to a Max buffer, so we have to put the file somewhere.
-function saveToFile(url, filepath, onSuccess, onErr) {
-
-	let audio = new Buffer("");
-	const readRequest = http.request(url, res => {
-		res.on("data", data => {
-			audio = Buffer.concat([audio, data]);
-		});
-		res.on("end", () => {
-			fs.writeFile(filepath, audio, {
-				encoding: "utf8",
-				flag: "w+"
-			}, (writeerr) => {
-				if (writeerr) {
-					onErr(writeerr);
-				} else {
-					onSuccess();
-				}
-			});
-		});
+async function saveToFile(url, filepath) {
+	const writer = fs.createWriteStream(filepath);
+	const response = await axios.get(url, { responseType: "stream" });
+	response.data.pipe(writer);
+	return new Promise((resolve, reject) => {
+		writer.on("finish", resolve);
+		writer.on("error", reject);
 	});
-
-	readRequest.end();
 }
 
 // Declare handlers
 maxAPI.addHandlers({
-	search: (query, duration) => {
-		const fields = "id,name,url,previews";
-		const page = 1;
-		const filter = duration ? encodeURIComponent(`duration:[0.0 TO ${duration}]`) : "";
-		const sort = "score";
-		const token = process.env.FREESOUND_CLIENT_SECRET;
-		freesound.textSearch(query, {
-			page,
-			filter,
-			sort,
-			fields,
-			token
-		}, (response) => {
-			const results = response.results;
-			// const count = results.length;
-
-			// Output the results as a list
-			maxAPI.outlet(["search", query, results]);
-
-			// const idx = Math.floor(Math.random() * count);
-			// const result = results[idx];
-			// const sndurl = result.previews["preview-hq-mp3"];
-			// maxAPI.outlet(["url", result.url]);
-			// saveToTemporaryFile(sndurl, ".mp3", path => {
-			// 	maxAPI.outlet([query, path]);
-			// }, err => {
-			// 	maxAPI.post(err, maxAPI.POST_LEVELS.WARN);
-			// });
-		}, (err) => {
-			maxAPI.post(err);
-		});
-	},
-	preview: (key, url) => {
-		maxAPI.outlet("preview", key, "start", url);
-		tmp.tmpName({
-			postfix: ".mp3"
-		}, (err, dlpath) => {
-			if (err) {
-				maxAPI.post(err, maxAPI.POST_LEVELS.WARN);
-			}
-			saveToFile(url, dlpath, () => {
-				maxAPI.outlet("preview", key, "complete", url, dlpath);
-			}, dlerr => {
-				maxAPI.post(dlerr, maxAPI.POST_LEVELS.WARN);
+	search: async (query, duration) => {
+		try {
+			// See https://freesound.org/docs/api/resources_apiv2.html#search-resources
+			// For Details on the Freesound API Query Params
+			const { data } = await freesoundRequest.get("/search/text/", {
+				params: {
+					filter: duration ? `duration:[0.0 TO ${duration}]` : null,
+					fields: "id,name,url,previews",
+					page: 1,
+					query,
+					sort: "score"
+				}
 			});
-		});
+
+			const results = data.results;
+			// Output the results as a list
+			await maxAPI.outlet(["search", query, results]);
+		} catch (err) {
+			await maxAPI.post("Failed to search Freesound:", maxAPI.POST_LEVELS.ERROR);
+			await maxAPI.post(err.message, maxAPI.POST_LEVELS.ERROR);
+		}
 	},
-	download: (key, name, url, dlpath) => {
-		maxAPI.outlet("download", key, "start", url, dlpath);
-		const outpath = path.join(dlpath, `${name}.mp3`);
-		saveToFile(url, outpath, () => {
-			maxAPI.outlet("download", key, "complete", url, outpath);
-		}, dlerr => {
-			maxAPI.post(dlerr, maxAPI.POST_LEVELS.WARN);
-		});
+	preview: async (key, url) => {
+		try {
+			await maxAPI.outlet("preview", key, "start", url);
+			const dlPath = await tmpName({ postfix: ".mp3" });
+			await saveToFile(url, dlPath);
+			await maxAPI.outlet("preview", key, "complete", url, dlPath);
+		} catch (err) {
+			await maxAPI.post(`Failed to preview file: ${key}`, maxAPI.POST_LEVELS.WARN);
+			await maxAPI.post(err.message, maxAPI.POST_LEVELS.WARN);
+		}
+	},
+	download: async (key, name, url, dlPath) => {
+		try {
+			await maxAPI.outlet("download", key, "start", url, dlPath);
+			const outpath = path.join(dlPath, `${name}.mp3`);
+			await saveToFile(url, outpath);
+			await maxAPI.outlet("download", key, "complete", url, dlPath);
+		} catch (err) {
+			await maxAPI.post(err.message, maxAPI.POST_LEVELS.WARN);
+		}
 	}
 });

--- a/freesound/package-lock.json
+++ b/freesound/package-lock.json
@@ -1,281 +1,215 @@
 {
   "name": "n4m-freesound",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "aac": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/aac/-/aac-0.1.3.tgz",
-      "integrity": "sha1-61a2t7BzzIxDstsCfbrTMHPhSkg="
-    },
-    "abc": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/abc/-/abc-0.5.1.tgz",
-      "integrity": "sha1-VuaktW7WkarakEmnrTiCWJLsYbM="
-    },
-    "alac": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/alac/-/alac-0.1.0.tgz",
-      "integrity": "sha1-2hvzvV0IAdAZ/DicTK+Mq4W6/RM="
-    },
-    "assertion-error": {
+  "packages": {
+    "": {
+      "name": "n4m-freesound",
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
-      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js="
-    },
-    "async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-    },
-    "audiobuffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/audiobuffer/-/audiobuffer-0.2.0.tgz",
-      "integrity": "sha1-fPLfMHAarBhDM+r56O47AYMMhho=",
-      "requires": {
-        "underscore": "1.4.4"
-      },
+      "license": "MIT",
       "dependencies": {
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+        "axios": "^1.3.4",
+        "dotenv": "^6.0.0",
+        "tmp": "0.0.33"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
+      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
         }
       }
     },
-    "av": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/av/-/av-0.4.9.tgz",
-      "integrity": "sha1-jHFl9zlYClQeyVBxQjSSs//cbiA=",
-      "requires": {
-        "coffeeify": "0.6.0",
-        "speaker": "0.3.1"
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-      "optional": true
-    },
-    "chai": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-1.7.2.tgz",
-      "integrity": "sha1-ugfr1OGsE4opbN9pB3znS39KExc=",
-      "requires": {
-        "assertion-error": "1.0.0"
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "coffee-script": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
-      "integrity": "sha1-YplqhheAx15tUGnROCJyO3NAS/w=",
-      "requires": {
-        "mkdirp": "0.3.5"
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "coffeeify": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-0.6.0.tgz",
-      "integrity": "sha1-dcq6my6Sx4NskkZciDtqzJ2JRlI=",
-      "requires": {
-        "coffee-script": "1.7.1",
-        "convert-source-map": "0.3.5",
-        "through": "2.3.8"
-      }
-    },
-    "convert-source-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-      "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
-    },
-    "core-util-is": {
+    "node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "optional": true
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "optional": true,
-      "requires": {
-        "ms": "2.0.0"
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "engines": {
+        "node": ">=0.10.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    }
+  },
+  "dependencies": {
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "dotenv": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
       "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
     },
-    "flac": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/flac/-/flac-0.3.0.tgz",
-      "integrity": "sha1-5Z5BDDtIVqyX/1iKH1QwSsMYkzw=",
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
-        "abc": "0.5.1",
-        "fsa": "0.5.1"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
-    "freesound": {
-      "version": "git+https://git@github.com/Girlfriends/freesound.js.git#8f5ba28f2a6135632ac0cec8fce61970226f47e0",
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "web-audio-api": "0.2.2"
+        "mime-db": "1.52.0"
       }
-    },
-    "fsa": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/fsa/-/fsa-0.5.1.tgz",
-      "integrity": "sha1-xVUsgFY92gL4xoPsrJ9XwZUWE9s="
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "optional": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "optional": true
-    },
-    "mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-    },
-    "mp3": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mp3/-/mp3-0.1.0.tgz",
-      "integrity": "sha1-5T5HI+NGmO4//dzbYL+INWpJEME="
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "optional": true
-    },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "optional": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
-    "pcm-boilerplate": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pcm-boilerplate/-/pcm-boilerplate-0.1.1.tgz",
-      "integrity": "sha1-y4O0mf4lCMD2wYM4AD/OI54VCTE=",
-      "requires": {
-        "async": "0.2.10",
-        "chai": "1.7.2",
-        "underscore": "1.4.4"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        },
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
-        }
-      }
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "optional": true
-    },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "optional": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "speaker": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/speaker/-/speaker-0.3.1.tgz",
-      "integrity": "sha512-LEqSy+FHYHPZj4kX8NHylzaOmy+VIqj57enm2GS4B568hj0SdKDYa9jALCGQy43LZa/JmQk1iF0nlMVbS1PfPg==",
-      "optional": true,
-      "requires": {
-        "bindings": "1.3.0",
-        "debug": "2.6.9",
-        "nan": "2.10.0",
-        "readable-stream": "2.3.6"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "optional": true
-    },
-    "web-audio-api": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/web-audio-api/-/web-audio-api-0.2.2.tgz",
-      "integrity": "sha1-KlBItcI9a3lgXU7yT9e8MPM43iM=",
-      "requires": {
-        "aac": "0.1.3",
-        "alac": "0.1.0",
-        "async": "0.9.2",
-        "audiobuffer": "0.2.0",
-        "av": "0.4.9",
-        "flac": "0.3.0",
-        "mp3": "0.1.0",
-        "pcm-boilerplate": "0.1.1",
-        "underscore": "1.8.3"
+        "os-tmpdir": "~1.0.2"
       }
     }
   }

--- a/freesound/package.json
+++ b/freesound/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/Cycling74/n4m-examples#readme",
   "dependencies": {
+    "axios": "^1.3.4",
     "dotenv": "^6.0.0",
-    "freesound": "git+https://git@github.com/Girlfriends/freesound.js.git",
     "tmp": "0.0.33"
   }
 }


### PR DESCRIPTION
I have verified that this pull request:

* [x] there are no linting errors -- `npm run lint`, from the root of the n4m-examples repository
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Thank you!

Fixes #36 by replacing the custom freesound wrapper with a simple axios request, passing the Token via an Authorization header. It felt like the Freesound API is straightforward enough that the additional complexity of the wrapper layer isn't really helpful and additionally doesn't serve the purpose of an "example" by hiding a lot of complexity.

Also improved the file downloading to be stream based rather than loading the download into memory.